### PR TITLE
Add support for Xcode 7.2

### DIFF
--- a/AWSDeviceFarmiOSReferenceApp.xcodeproj/project.pbxproj
+++ b/AWSDeviceFarmiOSReferenceApp.xcodeproj/project.pbxproj
@@ -718,6 +718,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)\"",
@@ -823,6 +824,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = ADFiOSReferenceApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -836,6 +838,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = ADFiOSReferenceApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -859,7 +862,7 @@
 				INFOPLIST_FILE = ADFiOSReferenceAppTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = AWSDeviceFarmiOSReferenceAppTests;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ADFiOSReferenceApp.app/ADFiOSReferenceApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSDeviceFarmiOSReferenceApp.app/AWSDeviceFarmiOSReferenceApp";
 			};
 			name = Debug;
 		};
@@ -874,7 +877,7 @@
 				INFOPLIST_FILE = ADFiOSReferenceAppTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = AWSDeviceFarmiOSReferenceAppTests;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ADFiOSReferenceApp.app/ADFiOSReferenceApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSDeviceFarmiOSReferenceApp.app/AWSDeviceFarmiOSReferenceApp";
 			};
 			name = Release;
 		};
@@ -883,6 +886,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)\"",


### PR DESCRIPTION
- Changed ENABLE_BITCODE default value since this is optional
- The TestHost name was set to a custom name whereas it needs to be the
  same as the name of the test target